### PR TITLE
Fix the issue of repeated normalization in lpips

### DIFF
--- a/loss/lpips.py
+++ b/loss/lpips.py
@@ -89,8 +89,8 @@ class LPIPS(nn.Module):
     def forward(self, input, target):
         # Notably, the LPIPS w/ pre-trained weights expect the input in the range of [-1, 1].
         # However, our codebase assumes all inputs are in range of [0, 1], and thus a scaling is needed.
-        input = input * 2. - 1.
-        target = target * 2. - 1.
+        # input = input * 2. - 1.
+        # target = target * 2. - 1.
         in0_input, in1_input = (self.scaling_layer(input), self.scaling_layer(target))
         outs0, outs1 = self.net(in0_input), self.net(in1_input)
         feats0, feats1, diffs = {}, {}, {}


### PR DESCRIPTION
Hi, thanks for the great work!

This PR fixes a bug in LPIPS.py where the input tensors were normalized twice. Specifically:

- In the training scripts, [preprocess_imgs_vae()](https://github.com/End2End-Diffusion/REPA-E/blob/3ad80468e78ec4fc93e6e70aa08e7b3b8303a171/train_repae.py#L357) already scales the images to [-1, 1].
- However, in loss/lpips.py, the following lines redundantly applied [another transformation](https://github.com/End2End-Diffusion/REPA-E/blob/3ad80468e78ec4fc93e6e70aa08e7b3b8303a171/loss/lpips.py#L92C1-L93C34):
```
input = input * 2. - 1.
target = target * 2. - 1.
```
This caused LPIPS to receive inputs outside the expected range, distorting the perceptual similarity scores.

The changes in the PR commented out these two lines to prevent double normalization. After this fix, LPIPS receives correctly normalized inputs in [-1, 1].

Let me know if any additional adjustments are needed!
